### PR TITLE
Make the index.html page helpful.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,14 +3,21 @@
 <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Hello, World</title>
+    <title>The Unicode Consortium</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" media="screen" href="main.css" />
     <script src="main.js"></script>
 </head>
 <body>
-    <h1 class='hero'>
-        Hello, World.
+    <h1>
+        The Unicode Consortium
     </h1>
+    <p>You may be looking for:</p>
+    <ul>
+        <li><a href="https://unicode-org.github.io/icu/">ICU Documentation</a></li>
+        <li><a href="https://github.com/unicode-org">Unicode-org on github</a></li>
+        <li><a href="http://site.icu-project.org/">ICU-TC Home Page</a></li>
+        <li><a href="https://home.unicode.org/">Unicode Home Page</a></li>
+    </ul>
 </body>
 </html>


### PR DESCRIPTION
There is also https://unicode-org.github.io/icu-docs/ - but:

* the "dev" entries (https://unicode-org.github.io/icu-docs/apidoc/dev/icu4c/ and https://unicode-org.github.io/icu-docs/apidoc/dev/icu4j/) still point at 67, so I didn't want to advertise this. https://github.com/unicode-org/icu-docs/pull/16 updates dev ICU4C to current master.
* the links to directories don't work, because GitHub Pages is not generating a directory listing. For those directories, browsing from https://github.com/unicode-org/icu-docs#icu-docs---international-components-for-unicode-docs is better.